### PR TITLE
🔒 [security fix] Prevent wildcard injection in search queries

### DIFF
--- a/backend/app/Http/Controllers/AplicacionController.php
+++ b/backend/app/Http/Controllers/AplicacionController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\StoreAplicacionRequest;
 use App\Http\Requests\UpdateAplicacionRequest;
 use App\Http\Resources\AplicacionResource;
 use Illuminate\Http\Request;
+use App\Support\QueryHelper;
 use OpenApi\Annotations as OA;
 
 class AplicacionController extends Controller
@@ -35,7 +36,7 @@ class AplicacionController extends Controller
             $query = Aplicacion::with(['candidato.usuario', 'trabajo.empresa.usuario']);
 
             if ($request->has('search')) {
-                $search = $request->input('search');
+                $search = QueryHelper::escapeLike($request->input('search'));
                 $query->where(function ($q) use ($search) {
                     $q->whereHas('candidato.usuario', function ($sq) use ($search) {
                         $sq->where('nombre', 'like', "%{$search}%");

--- a/backend/app/Http/Controllers/GastoController.php
+++ b/backend/app/Http/Controllers/GastoController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Gasto;
 use App\Models\Empresa;
 use Illuminate\Http\Request;
+use App\Support\QueryHelper;
 use OpenApi\Annotations as OA;
 
 class GastoController extends Controller
@@ -42,7 +43,7 @@ class GastoController extends Controller
         }
 
         if ($request->has('search')) {
-            $search = $request->input('search');
+            $search = QueryHelper::escapeLike($request->input('search'));
             $query->where(function ($q) use ($search) {
                 $q->where('concepto', 'like', "%{$search}%")
                   ->orWhereHas('empresa.usuario', function ($sq) use ($search) {

--- a/backend/app/Http/Controllers/TrabajoController.php
+++ b/backend/app/Http/Controllers/TrabajoController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\StoreTrabajoRequest;
 use App\Http\Requests\UpdateTrabajoRequest;
 use App\Http\Resources\TrabajoResource;
 use Illuminate\Http\Request;
+use App\Support\QueryHelper;
 use Illuminate\Support\Str;
 use OpenApi\Annotations as OA;
 
@@ -24,7 +25,7 @@ class TrabajoController extends Controller
      *     )
      * )
      */
-    public function index(Request $request)
+    public function index(Request )
     {
         $query = Trabajo::query()->with(['empresa.usuario']);
 
@@ -64,7 +65,7 @@ class TrabajoController extends Controller
         }
 
         if ($request->has('search')) {
-            $search = $request->input('search');
+            $search = QueryHelper::escapeLike($request->input('search'));
             $query->where(function ($q) use ($search) {
                 $q->where('titulo', 'like', "%{$search}%")
                     ->orWhereHas('empresa.usuario', function ($q) use ($search) {
@@ -74,7 +75,8 @@ class TrabajoController extends Controller
         }
 
         if ($request->filled('location')) {
-            $query->where('ubicacion', 'like', '%' . $request->location . '%');
+            $location = QueryHelper::escapeLike($request->location);
+            $query->where('ubicacion', 'like', '%' . $location . '%');
         }
 
         if ($request->filled('salary_min')) {

--- a/backend/app/Http/Controllers/UsuarioController.php
+++ b/backend/app/Http/Controllers/UsuarioController.php
@@ -6,6 +6,7 @@ use App\Models\Usuario;
 use App\Http\Requests\UpdateUsuarioRequest;
 use App\Http\Resources\UsuarioResource;
 use Illuminate\Http\Request;
+use App\Support\QueryHelper;
 use Illuminate\Support\Facades\Hash;
 use OpenApi\Annotations as OA;
 
@@ -29,7 +30,7 @@ class UsuarioController extends Controller
         $query = Usuario::query();
 
         if ($request->has('search')) {
-            $search = $request->input('search');
+            $search = QueryHelper::escapeLike($request->input('search'));
             $query->where(function ($q) use ($search) {
                 $q->where('nombre', 'like', "%{$search}%")
                   ->orWhere('email', 'like', "%{$search}%");

--- a/backend/app/Support/QueryHelper.php
+++ b/backend/app/Support/QueryHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Support;
+
+class QueryHelper
+{
+    /**
+     * Escapes characters that have special meaning in a LIKE clause.
+     *
+     * @param string|null $value
+     * @param string $char
+     * @return string
+     */
+    public static function escapeLike(?string $value, string $char = '\\'): string
+    {
+        return str_replace(
+            [$char, '%', '_'],
+            [$char.$char, $char.'%', $char.'_'],
+            (string) $value
+        );
+    }
+}

--- a/backend/tests/Feature/Security/LikeQueryTest.php
+++ b/backend/tests/Feature/Security/LikeQueryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Usuario;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LikeQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_search_can_handle_wildcard_characters_literally()
+    {
+        // Crear usuarios de prueba
+        Usuario::factory()->create(['nombre' => 'User Percent %', 'email' => 'percent@example.com']);
+        Usuario::factory()->create(['nombre' => 'User Underscore _', 'email' => 'underscore@example.com']);
+        Usuario::factory()->create(['nombre' => 'Normal User', 'email' => 'normal@example.com']);
+
+        // Como el endpoint tiene control de acceso, necesitamos un admin
+        $admin = Usuario::factory()->create(['rol' => 'ADMIN']);
+
+        // 1. Probar búsqueda con %
+        $response = $this->actingAs($admin)
+            ->getJson('/api/usuarios?search=%');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data'))->pluck('nombre');
+
+        // El fix debe prevenir que % actúe como comodín que coincide con todo
+        $this->assertNotContains('Normal User', $names, 'Search for % should not return "Normal User".');
+
+        // 2. Probar búsqueda con _
+        $response = $this->actingAs($admin)
+            ->getJson('/api/usuarios?search=_');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data'))->pluck('nombre');
+
+        // El fix debe prevenir que _ actúe como comodín de un solo carácter
+        // "Normal User" tiene caracteres que coincidirían con _ si fuera un comodín
+        $this->assertNotContains('Normal User', $names, 'Search for _ should not return "Normal User".');
+    }
+}

--- a/backend/tests/Unit/QueryHelperTest.php
+++ b/backend/tests/Unit/QueryHelperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\QueryHelper;
+use PHPUnit\Framework\TestCase;
+
+class QueryHelperTest extends TestCase
+{
+    public function test_escape_like_escapes_special_characters()
+    {
+        $this->assertEquals('100\\%', QueryHelper::escapeLike('100%'));
+        $this->assertEquals('user\\_name', QueryHelper::escapeLike('user_name'));
+        $this->assertEquals('back\\\\slash', QueryHelper::escapeLike('back\\slash'));
+        $this->assertEquals('mixed\\%\\_\\\\', QueryHelper::escapeLike('mixed%_\\'));
+    }
+
+    public function test_escape_like_does_not_affect_normal_characters()
+    {
+        $this->assertEquals('normal text', QueryHelper::escapeLike('normal text'));
+        $this->assertEquals('12345', QueryHelper::escapeLike('12345'));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Fixed a wildcard injection vulnerability in several controllers where search terms were directly interpolated into LIKE clauses.
⚠️ **Risk:** Attackers could use wildcard characters (`%`, `_`) to bypass search logic, potentially causing performance issues (DoS) or retrieving unintended records by crafting wide-reaching queries.
🛡️ **Solution:** Implemented a `QueryHelper::escapeLike()` utility that properly escapes SQL special characters before they are used in LIKE patterns. Updated `UsuarioController`, `AplicacionController`, `TrabajoController`, and `GastoController` to use this utility. Added comprehensive tests.

---
*PR created automatically by Jules for task [4991477340070250210](https://jules.google.com/task/4991477340070250210) started by @Isalvan*